### PR TITLE
feat: add RankingOrder to SingleCourseJson (for indexes)

### DIFF
--- a/PoliNetwork.Graduatorie.Parser/Objects/Json/SingleCourseJson.cs
+++ b/PoliNetwork.Graduatorie.Parser/Objects/Json/SingleCourseJson.cs
@@ -3,6 +3,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using PoliNetwork.Graduatorie.Common.Enums;
+using PoliNetwork.Graduatorie.Parser.Objects.RankingNS;
 using PoliNetwork.Graduatorie.Parser.Objects.Tables.Course;
 
 #endregion
@@ -19,6 +20,7 @@ public class SingleCourseJson
     public string? Name;
     public SchoolEnum? School;
     public int? Year;
+    public RankingOrder? RankingOrder;
 
     public int GetHashWithoutLastUpdate()
     {

--- a/PoliNetwork.Graduatorie.Parser/Objects/RankingNS/Ranking.cs
+++ b/PoliNetwork.Graduatorie.Parser/Objects/RankingNS/Ranking.cs
@@ -116,7 +116,8 @@ public class Ranking
             BasePath = schoolString + "/" + Year + "/",
             Year = Year,
             School = School,
-            Location = variable.Location
+            Location = variable.Location,
+            RankingOrder = RankingOrder,
         }));
 
         return result;


### PR DESCRIPTION
## Previous Behaviour
Frontend: when the user select the School and the Year, all the rankings of that selection are loaded to be divided in the correct phases (like "Prima Fase", "Extra-UE").
This is wrong, because the ranking file should be loaded only once the user has chosen to view that specific ranking.

## Fix
Add the field `RankingOrder` to `SingleCourseJson` so that the phase can be recognized without loading the specific ranking file but directly from the Index file.
  