### PR TITLE
fix!: correct extra-eu validation and rename fields

### DIFF
--- a/PoliNetwork.Graduatorie.Parser/Objects/RankingNS/RankingOrder.cs
+++ b/PoliNetwork.Graduatorie.Parser/Objects/RankingNS/RankingOrder.cs
@@ -11,53 +11,49 @@ namespace PoliNetwork.Graduatorie.Parser.Objects.RankingNS;
 [JsonObject(MemberSerialization.Fields, NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class RankingOrder
 {
-    public bool? Anticipata;
-    public bool? ExtraEu;
-
-    public string? Phase;
+    public string? Phase; // the original string (e.g. "
 
     //esempio:
     //seconda graduatoria di seconda fase: {primary:2,secondary:2}
     //prima graduatoria di seconda fase:{primary:2, secondary:1}
     public int? Primary;
     public int? Secondary;
-    public bool IsEnglish = false;
+    public bool IsAnticipata; // used for DES/URB rankings until 2023
+    public bool IsExtraEu;
+    public bool IsEnglish;
 
-    public RankingOrder()
-    {
-    }
-
-    public RankingOrder(string phase, bool isEnglish = false)
+    public RankingOrder(string phase, bool isExtraEu = false, bool isEnglish = false)
     {
         Phase = phase;
+        ParsePhaseString(phase);
+        
+        IsExtraEu = isExtraEu;
         IsEnglish = isEnglish;
-        FixValues();
     }
 
-    private void FixValues()
+    private void ParsePhaseString(string phase)
     {
-        var s = Phase?.ToUpper().Trim() ?? "";
-        if (string.IsNullOrEmpty(s))
-            return;
-
-        ExtraEu = s.Contains("EXTRA");
+        var s = phase.ToUpper().Trim();
+        if (string.IsNullOrEmpty(s)) return;
+        
         var strings = s.Split(" ");
-        Primary = GetCount(strings, "FASE");
-        Secondary = GetCount(strings, "GRADUATORIA");
-        Anticipata = s.Contains("ANTICIPATA");
+        
+        IsAnticipata = s.Contains("ANTICIPATA");
+        if (IsAnticipata) return;
+        
+        Primary = ExtractPhaseNumberByKey(strings, "FASE");
+        Secondary = ExtractPhaseNumberByKey(strings, "GRADUATORIA");
     }
 
-    private static int? GetCount(IReadOnlyList<string> s, string key)
+    private static int? ExtractPhaseNumberByKey(IReadOnlyList<string> s, string key)
     {
-        for (var i = 0; i < s.Count; i++)
+        for (var i = 1; i < s.Count; i++)
         {
-            var item = s[i];
-            if (item != key) continue;
-            if (i - 1 < 0)
-                continue;
+            var curr = s[i];
+            if (curr != key) continue;
 
-            var item2 = s[i - 1];
-            return item2 switch
+            var prev = s[i - 1];
+            return prev switch
             {
                 "PRIMA" => 1,
                 "SECONDA" => 2,
@@ -78,12 +74,12 @@ public class RankingOrder
     public string GetId()
     {
         var idList = new List<string>();
-        if (Anticipata == true) idList.Add($"anticipata");
+        if (IsAnticipata) idList.Add($"anticipata");
         if (Primary != null) idList.Add($"{Primary}fase");
         if (Secondary != null) idList.Add($"{Secondary}grad");
         
         var cleanPhase = Phase?.Replace("_", "").Replace("-", "").Replace(" ", "_").ToLower() ?? "";
-        var noOrder = Anticipata == false && Primary == null && Secondary == null; 
+        var noOrder = IsAnticipata == false && Primary == null && Secondary == null; 
         var isSingleExtraEu = noOrder && cleanPhase.Contains("extraue");
 
         if (noOrder)
@@ -92,7 +88,7 @@ public class RankingOrder
         }
         
         idList.Add(IsEnglish ? "eng" : "ita");
-        if (ExtraEu == true && !isSingleExtraEu) idList.Add("extraeu"); // the second condition is to avoid double extraeu
+        if (IsExtraEu && !isSingleExtraEu) idList.Add("extraeu"); // the second condition is to avoid double extraeu
         
         var id = string.Join("_", idList);
         return id;
@@ -104,17 +100,15 @@ public class RankingOrder
         i ^= Phase?.GetHashCode() ?? "Phase".GetHashCode();
         i ^= Primary?.GetHashCode() ?? "Primary".GetHashCode();
         i ^= Secondary?.GetHashCode() ?? "Secondary".GetHashCode();
-        i ^= ExtraEu?.GetHashCode() ?? "ExtraEu".GetHashCode();
+        i ^= IsExtraEu.GetHashCode();
 
         return i;
     }
 
     public void Merge(RankingOrder? rankingRankingOrder)
     {
-        Anticipata ??= rankingRankingOrder?.Anticipata;
         Phase ??= rankingRankingOrder?.Phase;
         Primary ??= rankingRankingOrder?.Primary;
         Secondary ??= rankingRankingOrder?.Secondary;
-        ExtraEu ??= rankingRankingOrder?.ExtraEu;
     }
 }

--- a/PoliNetwork.Graduatorie.Parser/Utils/Transformer/ParserNS/Parser.cs
+++ b/PoliNetwork.Graduatorie.Parser/Utils/Transformer/ParserNS/Parser.cs
@@ -205,12 +205,15 @@ public class Parser
         ranking.School = school;
         ranking.Year = Convert.ToInt16(intestazioni[1].Split("Year ")[1].Split("/")[0]);
 
+        var extraEuStr = intestazioni[4].Split("\n")[0].ToLower();
+        var isExtraEu = extraEuStr.Contains("extra-ue");
+
         if (ranking.Year < 2024) {
             // layout valid until 2023
             var phase = string.Join(" ", intestazioni[3].Split(" - ")[1..]);
-            ranking.RankingOrder = new RankingOrder(phase);
+            ranking.RankingOrder = new RankingOrder(phase, isExtraEu);
             if (ranking.School == SchoolEnum.Architettura && ranking.RankingOrder.Primary == null &&
-                ranking.RankingOrder.Secondary == null && ranking.RankingOrder.ExtraEu == true)
+                ranking.RankingOrder.Secondary == null && ranking.RankingOrder.IsExtraEu)
             {
                 // this is a fallback for 2020-2023:
                 // POLIMI was used to add the ranking number (Secondary, e.g. "Prima Graduatoria") for ExtraEU starting 
@@ -225,7 +228,7 @@ public class Parser
             // layout valid since 2024 (if the layout changes again, make another else if)
             var phase = intestazioni[3];
             var isEnglish = intestazioni[2].Contains("taught in english") || intestazioni[2].Contains("erogati in inglese");
-            ranking.RankingOrder = new RankingOrder(phase, isEnglish);
+            ranking.RankingOrder = new RankingOrder(phase, isExtraEu, isEnglish);
         }
 
         ranking.Extra = intestazioni[4];


### PR DESCRIPTION
- BREAKING CHANGE: `ExtraEu` was renamed to `IsExtraEu`
- BREAKING CHANGE: `Anticipata` was renamed to `IsAnticipata`
- "extra-ue" is not included into phase by Polimi anymore, so we are using the `intestazione[4]` to define `IsExtraEu`
- `IsAnticipata` is not nullable since it's `false` by default
- removed useless comparisons (`== true`)
- rename some methods/vars for more comprehension 